### PR TITLE
chore: add contribution, security, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a reproducible problem in Eggent
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide a minimal and reproducible report.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Short description of the problem.
+      placeholder: The app crashes when...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List exact steps so we can reproduce.
+      placeholder: |
+        1. Go to...
+        2. Click...
+        3. See error...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: It should...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: It actually...
+    validations:
+      required: true
+  - type: dropdown
+    id: install_type
+    attributes:
+      label: Install/runtime mode
+      options:
+        - Docker setup
+        - Local setup (Node + npm)
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: App version, git commit, or branch name.
+      placeholder: main @ 1a2b3c4
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: macOS 15.5 / Ubuntu 24.04
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser (if relevant)
+      placeholder: Chrome 130, Safari 18, Firefox 130
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and errors
+      description: Paste stack traces, console logs, or container logs.
+      render: shell
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, recordings, or related details.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/eggent-ai/eggent/discussions
+    about: Ask usage questions and discuss ideas.
+  - name: Security vulnerability report
+    url: https://github.com/eggent-ai/eggent/security/advisories/new
+    about: Report sensitive vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest an improvement for Eggent
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Clear problem statements help us prioritize better.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: It is hard to...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you want to happen.
+      placeholder: Add a setting/button/workflow that...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds or alternatives you considered.
+  - type: textarea
+    id: impact
+    attributes:
+      label: User impact
+      description: Who benefits and how much?
+      placeholder: This helps users who...
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - UI/UX
+        - Chat/Agents
+        - MCP integration
+        - Memory/Knowledge
+        - Automation/Cron
+        - Install/Deployment
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and discussions first.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+Describe the problem and the intent of this PR.
+
+## What Changed
+
+- 
+
+## How to Test
+
+1. 
+2. 
+3. 
+
+## Checklist
+
+- [ ] PR is focused on one topic.
+- [ ] I ran `npm run lint`.
+- [ ] I ran `npm run build`.
+- [ ] I updated docs when behavior changed.
+- [ ] I linked related issue(s).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our Standards
+
+To keep collaboration productive and welcoming, participants are expected to:
+
+- be respectful and constructive
+- assume good intent and discuss ideas, not people
+- accept feedback professionally
+- avoid harassment, discrimination, and personal attacks
+
+Unacceptable behavior includes:
+
+- abusive or insulting language
+- intimidation, threats, or sustained disruption
+- publishing private information without consent
+- any conduct that would be inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies in all project spaces, including issues, pull requests, discussions, and other public communication channels connected to this repository.
+
+## Enforcement
+
+Maintainers may remove, edit, or reject comments, commits, code, issues, and other contributions that violate this Code of Conduct.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, contact the maintainers through repository communication channels and request a private follow-up.
+
+## Consequences
+
+Maintainers may take any action they deem appropriate, including warning, temporary restrictions, or removal from project spaces.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Eggent
+
+Thanks for helping improve Eggent.
+
+## Ways to Contribute
+
+- Report bugs
+- Propose features
+- Improve documentation
+- Submit code changes
+
+## Before Opening an Issue
+
+- Search existing issues to avoid duplicates.
+- Use the provided issue forms so maintainers get enough context.
+- Keep reports focused on one problem/request per issue.
+
+## Report a Bug
+
+Use the `Bug report` template and include:
+
+- what happened
+- what you expected
+- exact steps to reproduce
+- environment details (OS, browser, Docker/local)
+- relevant logs or screenshots
+
+If a bug is hard to reproduce, add a minimal reproducible example.
+
+## Request a Feature
+
+Use the `Feature request` template and include:
+
+- problem statement
+- proposed solution
+- alternatives considered
+- expected user impact
+
+## Development Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Production check:
+
+```bash
+npm run lint
+npm run build
+```
+
+## Pull Request Guidelines
+
+- Create a branch from `main`.
+- Keep PRs small and focused.
+- Explain the problem and solution clearly.
+- Link related issues (for example: `Closes #123`).
+- Include screenshots/GIFs for UI changes.
+- Update docs when behavior changes.
+
+## Commit Guidance
+
+Conventional commits are recommended but not required.
+
+Examples:
+
+- `fix(chat): handle empty tool output`
+- `feat(mcp): add server timeout setting`
+- `docs: clarify Docker setup`
+
+## Review and Triage
+
+- Maintainers triage new issues and PRs on a best-effort basis.
+- You may be asked for more context or a smaller repro.
+- Inactive issues/PRs may be closed after follow-up attempts.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eggent contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Eggent is a local-first AI workspace with:
 
 The app runs as a Next.js service and stores runtime state on disk (`./data`).
 
+## Contributing and Support
+
+- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Report a bug: [Bug report form](https://github.com/eggent-ai/eggent/issues/new?template=bug_report.yml)
+- Request a feature: [Feature request form](https://github.com/eggent-ai/eggent/issues/new?template=feature_request.yml)
+- Code of conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Security policy: [SECURITY.md](./SECURITY.md)
+
 ## Installation (All Supported Paths)
 
 | Path | Best for | Command |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided on a best-effort basis for the latest state of the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do not report security issues in public GitHub issues.
+
+Use GitHub private vulnerability reporting:
+
+- https://github.com/eggent-ai/eggent/security/advisories/new
+
+Include:
+
+- affected component and version/commit
+- clear reproduction steps or proof of concept
+- impact assessment
+- suggested mitigation (if known)
+
+## Response Process
+
+- initial acknowledgment target: within 72 hours
+- status updates: as investigation progresses
+- fix and disclosure timing: depends on severity and exploitability


### PR DESCRIPTION
## Summary

Set up a contributor-friendly GitHub workflow so users can clearly report bugs, request features, and submit PRs with consistent context.

## What Changed

- added `CONTRIBUTING.md` with:
  - contribution paths (bugs, features, docs, code)
  - issue/PR expectations
  - local dev and validation commands (`npm run lint`, `npm run build`)
- added `CODE_OF_CONDUCT.md`
- added `SECURITY.md` with private vulnerability reporting flow
- added `LICENSE` (MIT)
- added GitHub issue forms:
  - `.github/ISSUE_TEMPLATE/bug_report.yml`
  - `.github/ISSUE_TEMPLATE/feature_request.yml`
  - `.github/ISSUE_TEMPLATE/config.yml` (`blank_issues_enabled: false`, security/discussion links)
- added `.github/pull_request_template.md`
- updated `README.md` with a new **Contributing and Support** section linking all of the above

## Why

There is growing external interest in the project, and contributors need a clear, low-friction path for:
- bug reports
- feature proposals
- contribution standards
- security reporting

## Testing

- no runtime code changes
- docs/repository metadata only
- verified file structure and git status locally

## Notes

- chose MIT as default OSS license for now (can switch to Apache-2.0 in a follow-up if needed)
