### PR TITLE
perf(agent): optimize context for prompt caching and limit history

### DIFF
--- a/src/lib/agent/agent.ts
+++ b/src/lib/agent/agent.ts
@@ -13,6 +13,7 @@ import { getChat, saveChat } from "@/lib/storage/chat-store";
 import { createAgentTools } from "@/lib/tools/tool";
 import { getProjectMcpTools } from "@/lib/mcp/client";
 import type { AgentContext } from "@/lib/agent/types";
+import { History } from "@/lib/agent/history";
 import type { ChatMessage } from "@/lib/types";
 import { publishUiSyncEvent } from "@/lib/realtime/event-bus";
 
@@ -584,7 +585,10 @@ export async function runAgent(options: {
   const chat = await getChat(options.chatId);
   if (chat) {
     // Convert stored messages to ModelMessage format (including tool calls/results)
-    context.history = convertChatMessagesToModelMessages(chat.messages);
+    const allMessages = convertChatMessagesToModelMessages(chat.messages);
+    const history = new History(80);
+    history.addMany(allMessages);
+    context.history = history.getAll();
   }
 
   // Build tools: base + optional MCP tools from project .meta/mcp
@@ -717,7 +721,10 @@ export async function runAgentText(options: {
 
   const chat = await getChat(options.chatId);
   if (chat) {
-    context.history = convertChatMessagesToModelMessages(chat.messages);
+    const allMessages = convertChatMessagesToModelMessages(chat.messages);
+    const history = new History(80);
+    history.addMany(allMessages);
+    context.history = history.getAll();
   }
 
   const baseTools = createAgentTools(context, settings);

--- a/src/lib/agent/prompts.ts
+++ b/src/lib/agent/prompts.ts
@@ -201,9 +201,12 @@ export async function buildSystemPrompt(options: {
     }
   }
 
-  // 6. Current date/time
+  // 6. Current date/time (rounded to the hour for prompt caching)
+  const now = new Date();
+  now.setMinutes(0, 0, 0);
+  const dateStr = now.toISOString().slice(0, 13) + ":00:00Z";
   parts.push(
-    `\n## Current Information\n- Date/Time: ${new Date().toISOString()}\n- Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`
+    `\n## Current Information\n- Date/Time: ${dateStr}\n- Timezone: ${Intl.DateTimeFormat().resolvedOptions().timeZone}`
   );
 
   return parts.join("\n\n");


### PR DESCRIPTION
## Summary
- Round datetime in system prompt to the hour so the prefix stays stable across requests, enabling provider-side prompt caching (Anthropic ~5 min, OpenAI ~1 hr)
- Trim chat history to 80 messages via the existing `History` class to prevent context window overflow on long conversations

## Test plan
- [ ] `npm run lint` — passes
- [ ] `npm run build` — passes
- [ ] `npm run dev` → send multiple messages in a chat, verify responses are correct and older messages aren't lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)