### PR TITLE
feat: add Requesty as an OpenAI-compatible LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ GOOGLE_API_KEY=...
 # OpenRouter (optional)
 OPENROUTER_API_KEY=sk-or-...
 
+# Requesty (optional)
+REQUESTY_API_KEY=
+
 # Tavily Search (optional - for web search)
 TAVILY_API_KEY=tvly-...
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Main environment variables:
 | `ANTHROPIC_API_KEY` | No | Anthropic provider |
 | `GOOGLE_API_KEY` | No | Google provider |
 | `OPENROUTER_API_KEY` | No | OpenRouter provider |
+| `REQUESTY_API_KEY` | No | Requesty provider |
 | `TAVILY_API_KEY` | No | Web search integration |
 | `EXTERNAL_API_TOKEN` | No (auto-generated in setup scripts) | External message API auth token |
 | `TELEGRAM_BOT_TOKEN` | No | Telegram bot token |

--- a/src/app/api/models/route.ts
+++ b/src/app/api/models/route.ts
@@ -93,6 +93,8 @@ export async function GET(req: NextRequest) {
             } else if (provider === "openrouter" && process.env.OPENROUTER_API_KEY) {
                 // Special case for environment variables if not in settings explicitly
                 apiKey = process.env.OPENROUTER_API_KEY;
+            } else if (provider === "requesty" && process.env.REQUESTY_API_KEY) {
+                apiKey = process.env.REQUESTY_API_KEY;
             } else if (provider === "openai" && process.env.OPENAI_API_KEY) {
                 apiKey = process.env.OPENAI_API_KEY;
             } else if (provider === "anthropic" && process.env.ANTHROPIC_API_KEY) {
@@ -140,6 +142,25 @@ export async function GET(req: NextRequest) {
                 const data = await res.json();
 
                 // OpenRouter embeddings endpoint might return array directly or { data: [] }
+                const rawModels = Array.isArray(data) ? data : (data.data || []);
+
+                models = rawModels
+                    .map((m: { id: string; name?: string }) => ({
+                        id: m.id,
+                        name: m.name || m.id,
+                    }))
+                    .sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name));
+                break;
+            }
+
+            case "requesty": {
+                const res = await fetch("https://router.requesty.ai/v1/models", {
+                    headers: { Authorization: `Bearer ${apiKey}` },
+                });
+                if (!res.ok) throw new Error(`Requesty API error: ${res.status}`);
+                const data = await res.json();
+
+                // Requesty's /v1/models returns OpenAI shape ({ data: [] })
                 const rawModels = Array.isArray(data) ? data : (data.data || []);
 
                 models = rawModels

--- a/src/components/settings/model-wizards.tsx
+++ b/src/components/settings/model-wizards.tsx
@@ -161,6 +161,7 @@ function useModels(
         const dynamicProviders = [
           "openai",
           "openrouter",
+          "requesty",
           "ollama",
           "anthropic",
           "google",
@@ -179,6 +180,7 @@ function useModels(
       const dynamicProviders = [
         "openai",
         "openrouter",
+        "requesty",
         "ollama",
         "anthropic",
         "google",

--- a/src/lib/providers/llm-provider.ts
+++ b/src/lib/providers/llm-provider.ts
@@ -1633,6 +1633,14 @@ export function createModel(
       });
     }
 
+    case "requesty": {
+      return createOpenAICompatibleChatModel(config, {
+        providerName: "requesty",
+        apiKey: config.apiKey || process.env.REQUESTY_API_KEY || "",
+        fallbackBaseUrl: "https://router.requesty.ai/v1",
+      });
+    }
+
     case "ollama": {
       return createOpenAICompatibleChatModel(config, {
         providerName: "ollama",
@@ -1704,6 +1712,13 @@ export function createEmbeddingModel(config: {
         providerName: "openrouter",
         apiKey: config.apiKey || process.env.OPENROUTER_API_KEY || "",
         fallbackBaseUrl: "https://openrouter.ai/api/v1",
+      });
+
+    case "requesty":
+      return createOpenAICompatibleEmbeddingModel(config, {
+        providerName: "requesty",
+        apiKey: config.apiKey || process.env.REQUESTY_API_KEY || "",
+        fallbackBaseUrl: "https://router.requesty.ai/v1",
       });
 
     case "ollama":

--- a/src/lib/providers/model-config.ts
+++ b/src/lib/providers/model-config.ts
@@ -64,6 +64,14 @@ export const MODEL_PROVIDERS: Record<string, ProviderConfig> = {
     authMethods: ["api_key"],
     defaultAuthMethod: "api_key",
   },
+  requesty: {
+    name: "Requesty",
+    models: [],
+    envKey: "REQUESTY_API_KEY",
+    requiresApiKey: true,
+    authMethods: ["api_key"],
+    defaultAuthMethod: "api_key",
+  },
   ollama: {
     name: "Ollama",
     models: [],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,7 @@ export interface ModelConfig {
     | "anthropic"
     | "google"
     | "openrouter"
+    | "requesty"
     | "ollama"
     | "custom"
     | "codex-cli"
@@ -28,7 +29,7 @@ export interface AppSettings {
   chatModel: ModelConfig;
   utilityModel: ModelConfig;
   embeddingsModel: {
-    provider: "openai" | "openrouter" | "google" | "ollama" | "custom" | "mock";
+    provider: "openai" | "openrouter" | "requesty" | "google" | "ollama" | "custom" | "mock";
     model: string;
     apiKey?: string;
     baseUrl?: string;


### PR DESCRIPTION
## Summary

Adds **Requesty** as a native OpenAI-compatible LLM provider, mirroring the existing OpenRouter provider. Requesty is an OpenAI-compatible gateway: base URL `https://router.requesty.ai/v1`, `Authorization: Bearer <key>` auth, and `provider/model` model naming (e.g. `openai/gpt-4o-mini`). Because it speaks the OpenAI wire format, it reuses the same `createOpenAICompatibleChatModel` / `createOpenAICompatibleEmbeddingModel` paths OpenRouter uses, no new SDK or transport code.

## Wiring sites updated

- `src/lib/types.ts`: added `"requesty"` to the `ModelConfig.provider` union and to the narrower `embeddingsModel.provider` union.
- `src/lib/providers/model-config.ts`: added a `requesty` entry to `MODEL_PROVIDERS` (`name: "Requesty"`, `envKey: "REQUESTY_API_KEY"`, `requiresApiKey: true`, `authMethods: ["api_key"]`).
- `src/lib/providers/llm-provider.ts`: added `case "requesty"` to both the chat-model and embedding-model switches, calling the OpenAI-compatible factories with `providerName: "requesty"`, `process.env.REQUESTY_API_KEY`, and `fallbackBaseUrl: "https://router.requesty.ai/v1"`.
- `src/app/api/models/route.ts`: added a `requesty` model-listing branch (`GET https://router.requesty.ai/v1/models`, OpenAI `{ data: [] }` shape) plus the matching `REQUESTY_API_KEY` env-fallback lookup.
- `src/components/settings/model-wizards.tsx`: added `"requesty"` to the dynamic-provider lists so the settings wizard fetches its model list live.
- `README.md`: added `REQUESTY_API_KEY` row to the env table.
- `.env.example`: added a `# Requesty (optional)` block with `REQUESTY_API_KEY=`.

## Verification

- `npx tsc -p tsconfig.json --noEmit` introduces **no new type errors** (the pre-existing errors on `main` are unchanged by this PR).
- Ran a live chat completion against `https://router.requesty.ai/v1/chat/completions` with model `openai/gpt-4o-mini` and got a real `200` completion back.

## Links

- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

