### PR TITLE
fix: external project switch/create signals are silently dropped (Telegram sessions never switch projects)

### DIFF
--- a/src/lib/external/handle-external-message.ts
+++ b/src/lib/external/handle-external-message.ts
@@ -78,6 +78,26 @@ export class ExternalMessageError extends Error {
   }
 }
 
+function unwrapToolResultPayload(value: unknown): unknown {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) return value;
+  const record = value as Record<string, unknown>;
+  if (record.success !== undefined || record.action !== undefined) return value;
+  if (Array.isArray(record.content)) {
+    const texts: string[] = [];
+    for (const part of record.content) {
+      if (part && typeof part === "object" && !Array.isArray(part)) {
+        const partRecord = part as Record<string, unknown>;
+        if (partRecord.type === "text" && typeof partRecord.text === "string") {
+          texts.push(partRecord.text);
+        }
+      }
+    }
+    return texts.length > 0 ? texts.join("\n") : undefined;
+  }
+  return value;
+}
+
 function parseSwitchProjectSignal(
   message: ChatMessage
 ): SwitchProjectSignal | null {
@@ -85,7 +105,7 @@ function parseSwitchProjectSignal(
     return null;
   }
 
-  let parsed: unknown = message.toolResult ?? message.content;
+  let parsed: unknown = unwrapToolResultPayload(message.toolResult) ?? message.content;
   if (typeof parsed === "string") {
     const trimmed = parsed.trim();
     if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
@@ -125,7 +145,7 @@ function parseCreateProjectSignal(
     return null;
   }
 
-  let parsed: unknown = message.toolResult ?? message.content;
+  let parsed: unknown = unwrapToolResultPayload(message.toolResult) ?? message.content;
   if (typeof parsed === "string") {
     const trimmed = parsed.trim();
     if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {


### PR DESCRIPTION
## Bug

`parseSwitchProjectSignal` / `parseCreateProjectSignal` in `src/lib/external/handle-external-message.ts` expect the raw JSON payload (`{success, action, projectId, ...}`) directly in `message.toolResult`, with a fallback to `message.content`.

However, the runtime stores tool results as a wrapper object:

```json
{"content": [{"type": "text", "text": "{\n  \"success\": true,\n  \"action\": \"switch_project\", ...}"}], "details": {...}}
```

Because `toolResult` is non-null, `toolResult ?? content` never falls back to the `content` string (which does contain the parseable JSON), the wrapper fails the `success/action` checks, and the signal is silently dropped.

**Effect:** `switch_project` / `create_project` succeed inside the chat (the agent reports success), but the external session's `activeProjectId` is never updated. Telegram and external-API sessions therefore never actually switch projects; any apparent switching comes from unrelated fallbacks (first-project resolution on attachment messages and after `/new`), which makes the behavior look random.

Reproduce: `POST /api/external/message` with "switch to project X" → response has `switchedProject: null` and unchanged `context.activeProjectId` while `reply` claims success.

## Fix

Add `unwrapToolResultPayload()` that extracts the text payload from the tool-result wrapper (joining `content[].text` parts) before the existing string/object parsing; raw payloads and the `content` fallback keep working unchanged.

Verified on a self-hosted deployment: after the patch the same request returns `switchedProject: {toProjectId: ...}`, the session file persists `activeProjectId`, and follow-up messages land in the switched project's chat (also verified switch-by-name, switch-back, and not-found handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)